### PR TITLE
Change "requests" to "selenium webdriver"

### DIFF
--- a/ebAlert/ebayscrapping/ebayclass.py
+++ b/ebAlert/ebayscrapping/ebayclass.py
@@ -1,12 +1,12 @@
 import re
 from typing import Generator
 
-import requests
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
 from ebAlert import create_logger
 from ebAlert.core.config import settings
+from selenium import webdriver
 
 log = create_logger(__name__)
 
@@ -79,21 +79,18 @@ class EbayItemFactory:
         self.link = link
         web_pages = self.get_webpage()
         if web_pages:
-            articles = self.extract_item_from_page(self.get_webpage())
+            articles = self.extract_item_from_page(web_pages)
             self.item_list = [EbayItem(article) for article in articles]
         else:
             self.item_list = []
 
     def get_webpage(self) -> str:
-        custom_header = {
-            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0"
-        }
-        response = requests.get(self.link, headers=custom_header)
-        if response and response.status_code == 200:
-            return response.text
-        else:
-            print(f"<< webpage fetching error for url: {self.link}")
-
+        driver = webdriver.Chrome() # You can replace this with other web drivers
+        driver.get(self.link)
+        source = driver.page_source # Here is your populated data.
+        driver.quit() # don't forget to quit the driver!
+        return source
+        
     @staticmethod
     def extract_item_from_page(text: str) -> Generator:
         cleaned_response = text.replace("&#8203", "")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         'requests>=2.31',
         'bs4>=0.0.1',
         'sqlalchemy>=1.4',
-        'urllib3>=2.2.0'
+        'urllib3>=2.2.0',
+        'selenium'
     ],
     entry_points={'console_scripts': 'ebAlert=ebAlert.main:cli'}
 )


### PR DESCRIPTION
"requests" doesn't work anymore with Kleinanzeige. One possible solution is to open the page in a web-browser. Hence the use of "selenium webdriver".
The user must either have Chrome browser installed or must change "webdriver.Chrome" in "ebAlert/ebayscrapping/ebayclass.py" to his chosen browser.